### PR TITLE
Added Wordcount for Go

### DIFF
--- a/go/wordcount.go
+++ b/go/wordcount.go
@@ -39,7 +39,7 @@ func main() {
 		sort.Strings(words)
 
 		for _, word := range words {
-			fmt.Printf("%s %d\n", word, m[word])
+			fmt.Println(word, m[word])
 		}
 	}
 }


### PR DESCRIPTION
Includes an implementation of word count for Go (`wordcount.go`), used the Node example as a model for the program. Accepts normal stdin and outputs the same as the Node example.
