### PR TITLE
update link to ECMAScript specification

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -38,7 +38,7 @@ Continue your study of JavaScript via:
 
 - [Awesome JavaScript](https://github.com/sorrycc/awesome-javascript)
 - Another [Awesome JavaScript](https://js.libhunt.com/)
-- [The Official Language Specification](https://www.ecma-international.org/publications-and-standards/standards/ecma-262/)
+- [The Official Language Specification](https://tc39.es/ecma262/)
 - [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web)
 - [Axel Rauschmayer's Books](https://exploringjs.com/)
 - [Axel Rauschmayer's Blog](http://www.2ality.com/)


### PR DESCRIPTION
ECMA-262 is a living standard; it is better to link to the actual spec rather than the yearly snapshot that is taken and uploaded to the Ecma website, as it will be missing newer proposals that were added throughout the year and are already available in JS engines.  also:  the Ecma website itself has some availability issues that the TC39 website does not suffer from.