### PR TITLE
fix vyxal/first_twelve_fibs.vy

### DIFF
--- a/vyxal/first_twelve_fibs.vy
+++ b/vyxal/first_twelve_fibs.vy
@@ -1,2 +1,1 @@
-## Currently not working properly...
-0:›①⨥ɾ(|:↜⎙+
+k≈⎄+}12⊖”,


### PR DESCRIPTION
[Vyxal It Online!](https://vyxal.github.io/latest.html#H4sIAAAAAAAACqtWSssvyk0sUbIy1lHKSE1MSS1SslJS0lFKzk9JBbKyH3V2POpr0a41NHrUNe1Rw1wdoFxafn4JTF1aTmJ6sZJVdKyOUmZeQWkJlF2WWlScmZ8HVGOsZ6FnoFQLAK9zIq5pAAAA)

```
k≈⎄+}12⊖”,­⁡​‎‎⁪⁡⁪⁠⁪⁡⁪‏⁠‎⁪⁡⁪⁠⁪⁢⁪‏‏​⁡⁠⁡‌⁢​‎‎⁪⁡⁪⁠⁪⁣⁪‏⁠‎⁪⁡⁪⁠⁪⁤⁪‏⁠‎⁪⁡⁪⁠⁪⁢⁡⁪‏‏​⁡⁠⁡‌⁣​‎‎⁪⁡⁪⁠⁪⁢⁢⁪‏⁠‎⁪⁡⁪⁠⁪⁢⁣⁪‏⁠‎⁪⁡⁪⁠⁪⁢⁤⁪‏‏​⁡⁠⁡‌⁤​‎‎⁪⁡⁪⁠⁪⁣⁡⁪‏⁠‎⁪⁡⁪⁠⁪⁣⁢⁪‏‏​⁡⁠⁡‌­
k≈          # ‎⁡[0,1]
  ⎄+}       # ‎⁢generator, using + on the last 2 elements
     12⊖    # ‎⁣take the first 12
        ”,  # ‎⁤join on newlines and print
💎
```
Created with the help of [Luminespire](https://vyxal.github.io/Luminespire).